### PR TITLE
Use github url for pext radiobrowser plugin on info page

### DIFF
--- a/partials/info.html
+++ b/partials/info.html
@@ -47,7 +47,7 @@
             <li><a href="https://netradio.codeplex.com/">NetRadio</a>, source: <a href="https://netradio.codeplex.com/SourceControl/latest">codeplex</a> (Windows)</li>
             <li>Gnome Shell Radio Plugin <a href="https://extensions.gnome.org/extension/836/internet-radio/">Official Gnome Addon Repository</a>, source: <a href="https://github.com/hslbck/gnome-shell-extension-radio">Github</a></li>
             <li><a href="https://nesnomis.wordpress.com/sailfishosjolla/allradio/">AllRadio</a> (Jolla SailfishOS phones/tablets), source: <a href="https://github.com/nesnomis/harbour-allradio">Github</a></li>
-            <li>A <a href="https://notabug.org/Pext/pext_module_radiobrowser">plugin</a> for the Python-based extendable tool <a href="https://github.com/Pext/Pext">Pext</a> (Python)</li>
+            <li>A <a href="https://github.com/Pext/pext_module_radiobrowser">plugin</a> for the Python-based extendable tool <a href="https://github.com/Pext/Pext">Pext</a> (Python)</li>
             <li><a href="https://radiolise.gitlab.io/">Radio-li-se</a> is a beautiful web based client. (<a href="https://gitlab.com/radiolise/radiolise.gitlab.io">gitlab</a>)</li>
             <li><a href="https://bemba.surge.sh/">Radio Bempa</a> is a nice web based client.</li>
             <li><a href="http://board.dreambox-tools.info/showthread.php?9066-MusicCenter-8-Player-f%FCr-Musikfiles-Radio-de">MusicCenter</a> für DreamOS enigma2</li>


### PR DESCRIPTION
The notabug address is used as a mirror, which is stated as such on the site. The github url allows easier access as well as access to pull requests.