### PR TITLE
Update handful of links in info.html to https and update dreambox links

### DIFF
--- a/partials/info.html
+++ b/partials/info.html
@@ -28,7 +28,7 @@
         <br/>
         <ul>
             <li><a href="http://www.winamp.com/">Winamp</a> (Windows, OS X)</li>
-            <li><a href="http://videolan.org">VLC</a> (Windows, Linux, Android, OS X)</li>
+            <li><a href="https://www.videolan.org/">VLC</a> (Windows, Linux, Android, OS X)</li>
             <li><a href="https://www.clementine-player.org/">Clementine</a> (Windows, Linux, OS X)</li>
             <li>many many more....</li>
             <li>yes maybe Windows Media Player works too :)</li>
@@ -36,26 +36,26 @@
     </p>
     <p>It is used by the following projects:
         <ul>
-            <li><a href="http://www.programmierecke.net/programmed/rhythmbox-radio-browser.html">Rhythmbox-Radio-Browser</a> - A plugin for <a href="http://projects.gnome.org/rhythmbox/">rhythmbox</a></li>
+            <li><a href="https://www.programmierecke.net/programmed/rhythmbox-radio-browser.html">Rhythmbox-Radio-Browser</a> - A plugin for <a href="http://projects.gnome.org/rhythmbox/">rhythmbox</a></li>
             <li><a href="https://github.com/fossfreedom/radio-browser">Rhythmbox-Radio-Browser Fork for GTK 3.0</a></li>
             <li><a href="http://milki.include-once.org/streamtuner2/">StreamTuner2 (Contrib-Plugin)</a></li>
             <li>RadioDroid (Android: <a href="https://play.google.com/store/apps/details?id=net.programmierecke.radiodroid2">Google Play</a> / <a href="https://f-droid.org/repository/browse/?fdid=net.programmierecke.radiodroid2">F-Droid</a>) - <a href="https://github.com/segler-alex/RadioDroid">Source on GitHub</a></li>
-            <li><a href="http://www.dream-multimedia-tv.de/board/index.php?page=Thread&threadID=16645">DreamBox Plugin</a></li>
+            <li><a href="https://dreambox.de/board/index.php?thread/16645-e2-plugin-internetradio-mit-musik-visualisierung-und-webinterface/&postID=111994#post111994">DreamBox Plugin</a></li>
             <li><a href="https://play.google.com/store/apps/details?id=com.humbergsoftware.musicbox.androidapp">Musicbox</a> (Android)</li>
             <li><a href="https://github.com/haecker-felix/gradio">Gradio</a> (Linux/GTK/Gnome) - <a href="https://github.com/haecker-felix/gradio/wiki/Install-Gradio">HowTo Install</a></li>
-            <li>Kodi/XBMC Plugin <a href="http://addons.kodi.tv/show/plugin.audio.radiobrowser/">Official Kodi Addon Repository</a>, source: <a href="https://github.com/segler-alex/kodi-radio-browser">Github</a></li>
-            <li><a href="https://netradio.codeplex.com/">NetRadio</a>, source: <a href="https://netradio.codeplex.com/SourceControl/latest">codeplex</a> (Windows)</li>
+            <li>Kodi/XBMC Plugin <a href="https://kodi.tv/addon/music-add-ons-plugins/radio-browserinfo">Official Kodi Addon Repository</a>, source: <a href="https://github.com/segler-alex/kodi-radio-browser">Github</a></li>
+            <li><a href="https://archive.codeplex.com/?p=netradio">NetRadio</a>, source: <a href="https://archive.codeplex.com/?p=netradio">codeplex</a> (Windows)</li>
             <li>Gnome Shell Radio Plugin <a href="https://extensions.gnome.org/extension/836/internet-radio/">Official Gnome Addon Repository</a>, source: <a href="https://github.com/hslbck/gnome-shell-extension-radio">Github</a></li>
             <li><a href="https://nesnomis.wordpress.com/sailfishosjolla/allradio/">AllRadio</a> (Jolla SailfishOS phones/tablets), source: <a href="https://github.com/nesnomis/harbour-allradio">Github</a></li>
             <li>A <a href="https://github.com/Pext/pext_module_radiobrowser">plugin</a> for the Python-based extendable tool <a href="https://github.com/Pext/Pext">Pext</a> (Python)</li>
             <li><a href="https://radiolise.gitlab.io/">Radio-li-se</a> is a beautiful web based client. (<a href="https://gitlab.com/radiolise/radiolise.gitlab.io">gitlab</a>)</li>
             <li><a href="https://bemba.surge.sh/">Radio Bempa</a> is a nice web based client.</li>
-            <li><a href="http://board.dreambox-tools.info/showthread.php?9066-MusicCenter-8-Player-f%FCr-Musikfiles-Radio-de">MusicCenter</a> für DreamOS enigma2</li>
-            <li><a href="http://talk.maemo.org/showthread.php?t=94590">OCSP</a> <a href="https://sourceforge.net/projects/oscp/files/binaries/">Source</a> (Maemo)</li>
+            <li><a href="https://board.dreambox.tools/wbb/index.php?thread/9066-musiccenter-9-1-r0-musik-plugin-10-12-2017/&postID=169674#post169674">MusicCenter</a> for DreamOS enigma2</li>
+            <li><a href="https://talk.maemo.org/showthread.php?t=94590">OCSP</a> <a href="https://sourceforge.net/projects/oscp/files/binaries/">Source</a> (Maemo)</li>
             <li><a href="https://github.com/deeice/ziptuner">Ziptuner</a> (<a href="https://en.wikipedia.org/wiki/Zipit_wireless_messenger_(Z2)">Zipit</a>)</li>
             <li><a href="https://notabug.org/metadb-apps/InternetRadio">Internet Radio</a> (<a href="https://f-droid.org/repository/browse/?fdfilter=radio&fdid=community.peers.internetradio">F-Droid</a>, Android)</li>
             <li><a href="https://metadb.peers.community/">Meta DB</a></li>
-            <li><a href="http://www.indr.ch/335">335</a> - Radio app for android for visually impaired people<a href="https://github.com/indr/335">Source</a> <a href="https://play.google.com/store/apps/details?id=ch.indr.threethreefive">PlayStore</a></li>
+            <li><a href="http://www.indr.ch/projects/">335</a> - Radio app for android for visually impaired people<a href="https://github.com/indr/335">Source</a> <a href="https://play.google.com/store/apps/details?id=ch.indr.threethreefive">PlayStore</a></li>
             <li><a href="https://radios2s.scriptel.nl">RadioS2S</a> - Radio app for android <a href="https://play.google.com/store/apps/details?id=com.scriptel.simplyradio">PlayStore</a></li>
             <li><a href="https://apps.nextcloud.com/apps/radio">Radioplugin for NextCloud</a></li>
             <li>Castro (Chromecast Radio) - <a href="https://play.google.com/store/apps/details?id=guru.tall.castro">Playstore</a></li>


### PR DESCRIPTION
This pull request does the following:
* Update links to HTTPS where supported
* Update URLs that redirect or 404