### PR TITLE
Add Dockerfile for easy testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM node:8.11.1
  
 ADD . /root
 WORKDIR /root
-RUN ls
 RUN npm install -g bower gulp
 RUN bower install --allow-root
 RUN npm install gulp gulp-connect http-proxy-middleware

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:8.11.1
+ 
+RUN git clone https://github.com/rogersachan/radiobrowser.git
+WORKDIR /radiobrowser
+RUN ls
+RUN npm install -g bower gulp
+RUN bower install --allow-root
+RUN npm install gulp gulp-connect http-proxy-middleware
+ 
+EXPOSE 4200
+ 
+CMD gulp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:8.11.1
  
-RUN git clone https://github.com/rogersachan/radiobrowser.git
-WORKDIR /radiobrowser
+ADD . /root
+WORKDIR /root
 RUN ls
 RUN npm install -g bower gulp
 RUN bower install --allow-root

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@ var gulp = require('gulp'),
 gulp.task('connect', function () {
   connect.server({
     port: 4200,
+    host: "0.0.0.0",
     livereload: true,
     middleware: function (connect, opt) {
       return [ proxy('http://www.radio-browser.info/webservice', { changeOrigin: true }) ];


### PR DESCRIPTION
This pull request introduces a Dockerfile that allows building and running this Node.js app. I'll quote Hacker Noon's reasons for this since they put it really well:

> * You can set up development environment, fully capable. This can be done on any computer that supports Docker; there’s no need to install libraries, dependencies, download packages, mess with config files etc.
> * The application’s working environment remains consistent across the entire workflow. In other words, the app runs exactly the same for developer, tester, and client, be it on development, staging or production server.

See: https://hackernoon.com/how-to-dockerize-a-node-js-application-4fbab45a0c19

Run this file simply by building it and initializing it from CLI or using Kitematic.