### PR TITLE
Add gulp as local dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "angular-ui-bootstrap": "^2.5.6",
     "angular-ui-router": "^0.3.1",
     "bootstrap": "~3.3.6",
+    "gulp": "^3.9.1",
     "gulp-connect": "^5.0.0",
     "http-proxy-middleware": "^0.17.4",
     "jquery": "^3.3.1"


### PR DESCRIPTION
Gulp requires that it be installed both globally and locally for a project, and this pull request reflects that.