### PR TITLE
Add dev script to npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ website frontend with angular 1.x for [radio-browser api](https://github.com/seg
 
 Please note: API calls are proxied to **production environment** at <http://www.radio-browser.info/webservice>!
 
-- `gulp`
+- `gulp` or `npm run dev`
 - Visit your app at <http://localhost:4200/>
 
 There is also a Dockerfile

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "gulp production"
+    "start": "gulp production",
+    "dev": "gulp"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This pull request aliases the `gulp` task to `npm run dev` for convenience and IDE detection/support.