### PR TITLE
Remove dead link, fix typo, note API update needed

### DIFF
--- a/partials/users.html
+++ b/partials/users.html
@@ -297,14 +297,11 @@
                         </tr>
                         <tr>
                             <td>Radiobrowser (Angular 7)</td>
-                            <td>
-                                <a href="https://radio-browser.live">Homepage</a>, <a
-                                    href="https://github.com/kyjus25/radiobrowser">Sources</a>
-                            </td>
+                            <td><a href="https://github.com/kyjus25/radiobrowser">Sources</a></td>
                         </tr>
                         <tr>
-                            <td>Radio Bempa</td>
-                            <td><a href="https://bemba.surge.sh/">Homepage</a>
+                            <td>Radio Bemba</td>
+                            <td><a href="https://bemba.surge.sh/">Homepage</a> (Broken: needs update to API.radio-browser.info)
                             </td>
                         </tr>
                         <tr>


### PR DESCRIPTION
Removed link to https://radio-browser.live as the domain has expired. 
Fixed typo, and added note for Radio Bemba to update to API.radio-browser.info